### PR TITLE
Alternative proposal for 2.2.0

### DIFF
--- a/definitions/TagGroup/com.adlinktech.vision.inference/2.2.0/ClassificationTagGroup.json
+++ b/definitions/TagGroup/com.adlinktech.vision.inference/2.2.0/ClassificationTagGroup.json
@@ -14,8 +14,8 @@
             },
             {
                 "name":"model_id",
-                "description": "List of AI model identifiers associated with the result",
-                "kind":"STRING_SEQ",
+                "description": "AI model identifier associated with the result",
+                "kind":"STRING",
                 "optional":true,
                 "unit":"n/a"
             },
@@ -49,14 +49,14 @@
             },
             {
                 "name":"category_id",
-                "description":"List of classification category/class IDs",
-                "kind":"STRING_SEQ",
+                "description":"Classification category/class ID",
+                "kind":"STRING",
                 "unit":"n/a"
             },
             {
                 "name":"category_label",
-                "description":"List of human interpreted category names",
-                "kind":"STRING_SEQ",
+                "description":"Human interpreted category names",
+                "kind":"STRING",
                 "unit":"n/a"
             },
             {

--- a/definitions/TagGroup/com.adlinktech.vision.inference/2.2.0/DetectionBoxTagGroup.json
+++ b/definitions/TagGroup/com.adlinktech.vision.inference/2.2.0/DetectionBoxTagGroup.json
@@ -14,8 +14,8 @@
             },
             {
                 "name":"model_id",
-                "description": "List of AI model identifiers associated with the result",
-                "kind":"STRING_SEQ",
+                "description": "AI model identifier associated with the result",
+                "kind":"STRING",
                 "optional":true,
                 "unit":"n/a"
             },
@@ -56,15 +56,15 @@
             },
             {
                 "name":"category_id",
-                "description":"List of classification category/class IDs",
-                "kind":"STRING_SEQ",
+                "description":"Classification category/class ID",
+                "kind":"STRING",
                 "optional":true,
                 "unit":"n/a"
             },
             {
                 "name":"category_label",
-                "description":"List of human interpreted category names",
-                "kind":"STRING_SEQ",
+                "description":"Human interpreted category name",
+                "kind":"STRING",
                 "optional":true,
                 "unit":"n/a"
             },
@@ -95,6 +95,13 @@
             {
                 "name":"probability",
                 "description":"Network confidence",
+                "kind":"FLOAT64",
+                "optional":true,
+                "unit":"Percentage"
+            },
+            {
+                "name":"tracker_probability",
+                "description":"Tracker confidence",
                 "kind":"FLOAT64",
                 "optional":true,
                 "unit":"Percentage"

--- a/definitions/TagGroup/com.adlinktech.vision.inference/2.2.0/DetectionPointTagGroup.json
+++ b/definitions/TagGroup/com.adlinktech.vision.inference/2.2.0/DetectionPointTagGroup.json
@@ -14,7 +14,7 @@
             },
             {
                 "name":"model_id",
-                "description": "List of AI model identifiers associated with the result",
+                "description": "AI model identifier associated with the result",
                 "kind":"STRING_SEQ",
                 "optional":true,
                 "unit":"n/a"
@@ -65,15 +65,15 @@
             },
             {
                 "name":"category_id",
-                "description":"List of classification category/class IDs",
-                "kind":"STRING_SEQ",
+                "description":"Classification category/class ID",
+                "kind":"STRING",
                 "optional":true,
                 "unit":"n/a"
             },
             {
                 "name":"category_label",
-                "description":"List of human interpreted category names",
-                "kind":"STRING_SEQ",
+                "description":"Human interpreted category name",
+                "kind":"STRING",
                 "optional":true,
                 "unit":"n/a"
             },
@@ -98,6 +98,13 @@
             {
                 "name":"probability",
                 "description":"Network confidence",
+                "kind":"FLOAT64",
+                "optional":true,
+                "unit":"Percentage"
+            },
+            {
+                "name":"tracker_probability",
+                "description":"Tracker confidence",
                 "kind":"FLOAT64",
                 "optional":true,
                 "unit":"Percentage"
@@ -145,15 +152,15 @@
         "tags": [
             {
                 "name": "category_id",
-                "description": "List of graph category/class IDs",
-                "kind": "STRING_SEQ",
+                "description": "Graph category/class ID",
+                "kind": "STRING",
                 "optional": true,
                 "unit": "n/a"
             },
             {
                 "name": "category_label",
-                "description": "List of human interpreted category names",
-                "kind": "STRING_SEQ",
+                "description": "Human interpreted category name",
+                "kind": "STRING",
                 "optional": true,
                 "unit": "n/a"
             },
@@ -166,7 +173,7 @@
             },
             {
                 "name": "layout",
-                "description": "List of Graph Nodes representing this graph",
+                "description": "List of Graph edges representing this graph",
                 "kind": "MULTI_DIM_NVP",
                 "dimensions": 1,
                 "unit": "n/a",
@@ -191,8 +198,8 @@
             },
             {
                 "name": "label",
-                "description": "List of labels associated with this edge",
-                "kind": "STRING_SEQ",
+                "description": "Label associated with this edge",
+                "kind": "STRING",
                 "optional": true,
                 "unit": "n/a"
             }

--- a/definitions/TagGroup/com.adlinktech.vision.inference/2.2.0/RawInferenceResultTagGroup.json
+++ b/definitions/TagGroup/com.adlinktech.vision.inference/2.2.0/RawInferenceResultTagGroup.json
@@ -14,8 +14,8 @@
             },
             {
                 "name":"model_id",
-                "description": "List of AI model identifiers associated with the result",
-                "kind":"STRING_SEQ",
+                "description": "AI model identifier associated with the result",
+                "kind":"STRING",
                 "optional":true,
                 "unit":"n/a"
             },

--- a/definitions/TagGroup/com.adlinktech.vision.inference/2.2.0/SegmentationTagGroup.json
+++ b/definitions/TagGroup/com.adlinktech.vision.inference/2.2.0/SegmentationTagGroup.json
@@ -13,9 +13,9 @@
                 "unit":"NUM"
             },
             {
-                "name":"model_id",
-                "description": "List of AI model identifiers associated with the result",
-                "kind":"STRING_SEQ",
+                "name":"model",
+                "description": "AI model identifier associated with the result",
+                "kind":"STRING",
                 "optional":true,
                 "unit":"n/a"
             },
@@ -68,15 +68,15 @@
             },
             {
                 "name":"category_id",
-                "description":"List of classification category/class IDs",
-                "kind":"STRING_SEQ",
+                "description":"Classification category/class ID",
+                "kind":"STRING",
                 "optional":true,
                 "unit":"n/a"
             },
             {
                 "name":"category_label",
-                "description":"List of human interpreted category names",
-                "kind":"STRING_SEQ",
+                "description":"Human interpreted category name",
+                "kind":"STRING",
                 "optional":true,
                 "unit":"n/a"
             },
@@ -102,6 +102,13 @@
             {
                 "name":"probability",
                 "description":"Network confidence",
+                "kind":"FLOAT64",
+                "optional":true,
+                "unit":"Percentage"
+            },
+            {
+                "name":"tracker_probability",
+                "description":"Tracker confidence",
                 "kind":"FLOAT64",
                 "optional":true,
                 "unit":"Percentage"


### PR DESCRIPTION
This is an alternative proposal for 2.2.0 with the following changes from my other proposal:

* Changed model_id, category_id and category_label back to a single string. The proposal is to use Alex's parent_inference_id mechanism instead.
* Added an optional tracker_probability tag to tag groups with tracker support as DeepStream supports a separate confidence value for this field.